### PR TITLE
Improve testing of `Hash` refinements (Slice and Transform)

### DIFF
--- a/spec/gorilla-patch/slice_spec.rb
+++ b/spec/gorilla-patch/slice_spec.rb
@@ -4,32 +4,8 @@ describe GorillaPatch::Slice do
 	using GorillaPatch::Slice
 
 	describe Hash do
-		class HashWithSetterCounter < Hash
-			attr_reader :setter_counter
-
-			def []=(key, value)
-				@setter_counter ||= 0
-				@setter_counter += 1
-				super
-			end
-		end
-
-		let(:init_hash) { HashWithSetterCounter[a: 1, b: 2, c: 3] }
+		let(:init_hash) { { a: 1, b: 2, c: 3 } }
 		let(:sliced_keys) { %i[a b] }
-
-		shared_examples 'calling super method if exist' do
-			if RUBY_VERSION >= '2.5'
-				it do
-					if subject.is_a?(HashWithSetterCounter)
-						expect(subject.setter_counter).to be_nil
-					else
-						is_expected.to be_instance_of(Hash)
-					end
-				end
-			else
-				it { expect(subject.setter_counter).to eq sliced_keys.size }
-			end
-		end
 
 		describe '#slice' do
 			subject { init_hash.slice(*sliced_keys) }
@@ -37,7 +13,17 @@ describe GorillaPatch::Slice do
 			it { is_expected.to eq(a: 1, b: 2) }
 			it { is_expected.not_to be init_hash }
 
-			include_examples 'calling super method if exist'
+			if RUBY_VERSION >= '2.5'
+				it do
+					expect(init_hash).not_to receive(:[])
+					subject
+				end
+			else
+				it do
+					expect(init_hash).to receive(:[]).exactly(sliced_keys.size).times
+					subject
+				end
+			end
 		end
 
 		describe '#slice!' do

--- a/spec/gorilla-patch/transform_spec.rb
+++ b/spec/gorilla-patch/transform_spec.rb
@@ -4,31 +4,7 @@ describe GorillaPatch::Transform do
 	using GorillaPatch::Transform
 
 	describe Hash do
-		class HashWithSetterCounter < Hash
-			attr_reader :setter_counter
-
-			def []=(key, value)
-				@setter_counter ||= 0
-				@setter_counter += 1
-				super
-			end
-		end
-
-		let(:init_hash) { HashWithSetterCounter[a: 1, b: 2, c: 3] }
-
-		shared_examples 'calling super method if exist' do
-			if RUBY_VERSION >= '2.4'
-				it do
-					if subject.is_a?(HashWithSetterCounter)
-						expect(subject.setter_counter).to be_nil
-					else
-						is_expected.to be_instance_of(Hash)
-					end
-				end
-			else
-				it { expect(subject.setter_counter).to eq init_hash.size }
-			end
-		end
+		let(:init_hash) { { a: 1, b: 2, c: 3 } }
 
 		describe '#transform_values' do
 			subject { init_hash.transform_values { |value| value * 10 } }
@@ -36,7 +12,17 @@ describe GorillaPatch::Transform do
 			it { is_expected.to eq(a: 10, b: 20, c: 30) }
 			it { is_expected.to_not be init_hash }
 
-			include_examples 'calling super method if exist'
+			if RUBY_VERSION >= '2.4'
+				it do
+					expect(init_hash).not_to receive(:each_with_object)
+					subject
+				end
+			else
+				it do
+					expect(init_hash).to receive(:each_with_object).once
+					subject
+				end
+			end
 		end
 
 		describe '#transform_values!' do
@@ -45,7 +31,17 @@ describe GorillaPatch::Transform do
 			it { is_expected.to eq(a: 10, b: 20, c: 30) }
 			it { is_expected.to be init_hash }
 
-			include_examples 'calling super method if exist'
+			if RUBY_VERSION >= '2.4'
+				it do
+					expect(init_hash).not_to receive(:[]=)
+					subject
+				end
+			else
+				it do
+					expect(init_hash).to receive(:[]=).exactly(init_hash.size).times
+					subject
+				end
+			end
 		end
 	end
 end


### PR DESCRIPTION
for methods, which were released in new Ruby versions

Use `expect(object).to receive(method)` from `rspec-mocks`
instead of self-writen hacks.